### PR TITLE
Detailed redis replication status logs

### DIFF
--- a/mocks/service/redis/Client.go
+++ b/mocks/service/redis/Client.go
@@ -51,6 +51,27 @@ func (_m *Client) GetNumberSentinelsInMemory(ip string) (int32, error) {
 	return r0, r1
 }
 
+// GetReplicationInfo provides a mock function with given fields: ip, password
+func (_m *Client) GetReplicationInfo(ip string, password string) (string, error) {
+	ret := _m.Called(ip, password)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string, string) string); ok {
+		r0 = rf(ip, password)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(ip, password)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetSentinelMonitor provides a mock function with given fields: ip
 func (_m *Client) GetSentinelMonitor(ip string) (string, string, error) {
 	ret := _m.Called(ip)

--- a/operator/redisfailover/service/check.go
+++ b/operator/redisfailover/service/check.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -12,6 +13,21 @@ import (
 	"github.com/spotahome/redis-operator/log"
 	"github.com/spotahome/redis-operator/service/k8s"
 	"github.com/spotahome/redis-operator/service/redis"
+)
+
+// TODO this is duplicated over from service/redis/client.go
+const (
+	sentinelsNumberREString = "sentinels=([0-9]+)"
+	slaveNumberREString     = "slaves=([0-9]+)"
+	sentinelStatusREString  = "status=([a-z]+)"
+	redisMasterHostREString = "master_host:([0-9.]+)"
+	redisRoleMaster         = "role:master"
+	redisSyncing            = "master_sync_in_progress:1"
+	redisMasterSillPending  = "master_host:127.0.0.1"
+	redisLinkUp             = "master_link_status:up"
+	redisPort               = "6379"
+	sentinelPort            = "26379"
+	masterName              = "mymaster"
 )
 
 // RedisFailoverCheck defines the interface able to check the correct status of a redis failover
@@ -339,5 +355,29 @@ func (r *RedisFailoverChecker) CheckRedisSlavesReady(ip string, rFailover *redis
 		return false, err
 	}
 
-	return r.redisClient.SlaveIsReady(ip, password)
+	// JH: This just does what the r.redisClient.SlaveIsReady does, except breaks out the checks line by line
+	// so that we know why the replica is not ready
+	// TODO enhancement: properly parse the replication info instead of just doing string matches
+	// TODO enhancement: add more checks here
+	replicationInfo, err := r.redisClient.GetReplicationInfo(ip, password)
+	if err != nil {
+		return false, err
+	}
+
+	if strings.Contains(replicationInfo, redisSyncing) {
+		r.logger.Debugf("Replica %s is not ready: is still syncing - %s", ip, redisSyncing)
+		return false, err
+	}
+
+	if strings.Contains(replicationInfo, redisMasterSillPending) {
+		r.logger.Debugf("Replica %s is not ready: master still pending - %s", ip, redisMasterSillPending)
+		return false, err
+	}
+
+	if !strings.Contains(replicationInfo, redisLinkUp) {
+		r.logger.Debugf("Replica %s is not ready: redis link not up - expected %s", ip, redisLinkUp)
+		return false, err
+	}
+
+	return true, nil
 }

--- a/service/redis/client.go
+++ b/service/redis/client.go
@@ -26,6 +26,7 @@ type Client interface {
 	SetCustomSentinelConfig(ip string, configs []string) error
 	SetCustomRedisConfig(ip string, configs []string, password string) error
 	SlaveIsReady(ip, password string) (bool, error)
+	GetReplicationInfo(ip, password string) (string, error)
 }
 
 type client struct {
@@ -335,4 +336,19 @@ func (c *client) SlaveIsReady(ip, password string) (bool, error) {
 		strings.Contains(info, redisLinkUp)
 
 	return ok, nil
+}
+
+func (c *client) GetReplicationInfo(ip, password string) (string, error) {
+	options := &rediscli.Options{
+		Addr:     fmt.Sprintf("%s:%s", ip, redisPort),
+		Password: password,
+		DB:       0,
+	}
+	rClient := rediscli.NewClient(options)
+	defer rClient.Close()
+	info, err := rClient.Info("replication").Result()
+	if err != nil {
+		return "", err
+	}
+	return info, nil
 }


### PR DESCRIPTION
Fixes # .

Changes proposed on the PR:
- Its hard to determine why a redis pod is not ready. This provides some detailed logging on whats going on
- It breaks apart the `SlaveIsReady` function 
- 